### PR TITLE
[BREAKING CHANGE] Provide the filePath to the baseURI function

### DIFF
--- a/lib/build-bundler.js
+++ b/lib/build-bundler.js
@@ -32,7 +32,8 @@ module.exports = ({ source, target, fingerprint, configDir }) => {
 							return {
 								changed: true,
 								target: path.relative(configDir, targetPath),
-								output: path.relative(configDir, outputPath)
+								output: path.relative(configDir, outputPath),
+								filePath: path.relative(target, outputPath)
 							};
 						});
 					});

--- a/lib/build-manifest-writer.js
+++ b/lib/build-manifest-writer.js
@@ -1,5 +1,4 @@
 let { createFile } = require("faucet-pipeline-util");
-let { basename } = require("path");
 
 // Create a writer for a manifest
 //
@@ -20,7 +19,7 @@ module.exports = manifestConfig => {
 
 function updateManifest(results, manifest, { baseURI }) {
 	return results.reduce((acc, result) => {
-		acc[result.target] = baseURI(result.output, basename(result.output));
+		acc[result.target] = baseURI(result.output, result.filePath);
 		return acc;
 	}, manifest);
 }

--- a/test/run
+++ b/test/run
@@ -64,3 +64,8 @@ begin "./test_fingerprint"
 	assert_identical "./dist/test-e59ff97941044f85df5297e1c302d260.txt" "./src/test.txt"
 	assert_identical "./dist/manifest.json" "./expected.json"
 end
+
+begin "./test_manifest_base_uri"
+	faucet
+	assert_identical "./dist/manifest.json" "./expected.json"
+end

--- a/test/test_fingerprint/expected.json
+++ b/test/test_fingerprint/expected.json
@@ -1,1 +1,1 @@
-{"dist/test.txt":"/assets/dist/test-e59ff97941044f85df5297e1c302d260.txt"}
+{"dist/inner/test2.txt":"/assets/dist/inner/test2-e59ff97941044f85df5297e1c302d260.txt","dist/test.txt":"/assets/dist/test-e59ff97941044f85df5297e1c302d260.txt"}

--- a/test/test_fingerprint/src/inner/test2.txt
+++ b/test/test_fingerprint/src/inner/test2.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/test_manifest_base_uri/expected.json
+++ b/test/test_manifest_base_uri/expected.json
@@ -1,0 +1,1 @@
+{"dist/inner/test2.txt":"/assets/inner/test2-e59ff97941044f85df5297e1c302d260.txt","dist/test.txt":"/assets/test-e59ff97941044f85df5297e1c302d260.txt"}

--- a/test/test_manifest_base_uri/faucet.config.js
+++ b/test/test_manifest_base_uri/faucet.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+	static: {
+		manifest: {
+			file: "./dist/manifest.json",
+			baseURI: (bundlePath, filePath) => `/assets/${filePath}`
+		},
+		bundles: [{
+			source: "src",
+			target: "dist"
+		}]
+	}
+};

--- a/test/test_manifest_base_uri/src/inner/test2.txt
+++ b/test/test_manifest_base_uri/src/inner/test2.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/test_manifest_base_uri/src/test.txt
+++ b/test/test_manifest_base_uri/src/test.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
Turns out, it doesn't make a lot of sense to provide the basename for nested files. Instead we provide the filePath, which is the path relative to the target folder.