### PR TITLE
Support for single files. Closes #3

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,19 +1,17 @@
 let path = require("path");
 let { readdir, stat } = require("./promisified-fs");
 
-function tree(directory, relativeTo = directory) {
-	return readdir(directory).then(entries => {
-		return Promise.all(entries.map(entry => {
-			let fullEntry = path.join(directory, entry);
-
-			return stat(fullEntry).then(results => {
-				if(results.isDirectory()) {
-					return tree(fullEntry, relativeTo);
-				} else {
-					return path.relative(relativeTo, fullEntry);
-				}
+function tree(target, relativeTo = target) {
+	return stat(target).then(results => {
+		if(results.isDirectory()) {
+			return readdir(target).then(entries => {
+				return Promise.all(entries.map(entry => {
+					return tree(path.join(target, entry), relativeTo);
+				})).then(flatten);
 			});
-		})).then(flatten);
+		} else {
+			return [ path.relative(relativeTo, target) ];
+		}
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "faucet-pipeline-static",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"description": "Static Asset Pipeline",
 	"main": "lib/index.js",
 	"scripts": {

--- a/test/run
+++ b/test/run
@@ -69,3 +69,9 @@ begin "./test_manifest_base_uri"
 	faucet
 	assert_identical "./dist/manifest.json" "./expected.json"
 end
+
+begin "./test_single"
+	faucet --no-fingerprint
+	assert_identical "./dist/dist.txt" "./src.txt"
+end
+

--- a/test/test_single/dist.txt
+++ b/test/test_single/dist.txt
@@ -1,0 +1,1 @@
+A more creative text

--- a/test/test_single/faucet.config.js
+++ b/test/test_single/faucet.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	static: {
+		manifest: false,
+		bundles: [{
+			source: "src.txt",
+			target: "dist/dist.txt"
+		}]
+	}
+};

--- a/test/test_single/src.txt
+++ b/test/test_single/src.txt
@@ -1,0 +1,1 @@
+A more creative text


### PR DESCRIPTION
This adds support for copying single files like this:

```js
module.exports = {
  static: false,
    bundles: [{
      source: "src",
      target: "dist"
    }, {
      source: "bla.txt",
      target: "dist/bla.txt"
    }]
  }
}
```

Implementation: The implementation simply inverts the `tree` algorithm: When provided with a path, it first checks if it is a file or directory. If it is a file, it simply returns the path as an array. If it is a directory, it calls itself with each entry of the directory and concats the resulting arrays.