### PR TITLE
added support for resolving non-JavaScript implicit package references

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
+let fs = require("fs");
 let path = require("path");
 let { promisify } = require("faucet-pipeline-core/lib/util");
 let FileFinder = require("faucet-pipeline-core/lib/util/files/finder");
 
-let readFile = promisify(require("fs").readFile);
-let stat = promisify(require("fs").stat);
+let readFile = promisify(fs.readFile);
+let stat = promisify(fs.stat);
 
 module.exports = {
 	key: "static",
@@ -69,24 +70,33 @@ function processFiles(fileNames, config) {
 	return Promise.all(fileNames.map(fileName => processFile(fileName, config)));
 }
 
-function processFile(fileName,
+async function processFile(fileName,
 		{ source, target, targetDir, fingerprint, assetManager, plugins }) {
 	let sourcePath = path.join(source, fileName);
 	let targetPath = path.join(target, fileName);
 
-	return readFile(sourcePath).
-		then(content => {
-			let type = determineFileType(sourcePath);
-			let plugin = type && plugins[type];
-			return plugin ? plugin(content) : content;
-		}).
-		then(content => {
-			let options = { targetDir };
-			if(fingerprint !== undefined) {
-				options.fingerprint = fingerprint;
-			}
-			return assetManager.writeFile(targetPath, content, options);
-		});
+	try {
+		var content = await readFile(sourcePath); // eslint-disable-line no-var
+	} catch(err) {
+		if(err.code !== "ENOENT") {
+			throw err;
+		}
+		console.error(`WARNING: \`${sourcePath}\` no longer exists`);
+		return;
+	}
+
+	let type = determineFileType(sourcePath);
+	let plugin = type && plugins[type];
+	content = plugin ? plugin(content) : content;
+	if(content.then) {
+		content = await content;
+	}
+
+	let options = { targetDir };
+	if(fingerprint !== undefined) {
+		options.fingerprint = fingerprint;
+	}
+	return assetManager.writeFile(targetPath, content, options);
 }
 
 function determineFileType(sourcePath) {


### PR DESCRIPTION
> this allows resolving references to directories that don't contain an
> `index.js` (or whatever entry point is specified in `package.json`),
> e.g. `"material-design-icons/iconfont"`
>
> NB: this uses a simplistic heuristic, targeting root-level
>     `node_modules` - that's not perfect, but probably sufficient for
>     most cases (overloading `require.resolve` proved tricky)

not sure whether this is actually a good idea though

a proper solution relying on `require.resolve` might use https://github.com/ariporad/pirates - though that doesn't seem to apply to `require.resolve`? `console.log(require("module")._resolveFilename.toString())` (via `require.resolve.toString()`) might provide some additional insights

NB:
* this is currently untested (ran out of time for more)
* based on #36, so that needs to be merged first